### PR TITLE
Increase httpx timeout

### DIFF
--- a/neo4j_aura_sdk/client.py
+++ b/neo4j_aura_sdk/client.py
@@ -67,7 +67,7 @@ class AuraClient:
         self._base_url = base_url
         self._token = None
         self._token_expiration = 0
-        self._client = httpx.AsyncClient()
+        self._client = httpx.AsyncClient(timeout=30)
 
     @classmethod
     def from_env(cls):
@@ -328,6 +328,9 @@ class AuraClient:
             f"instances/{instanceId}/snapshots/{snapshotId}", model=SnapshotResponse
         )
 
+    async def get_upload_url(self, instanceId: str, size: int, ext: str="tar"):
+        path = "upload"
+    
     async def get_customer_managed_keys(self, tenantId: str = ""):
         path = "customer-managed-keys"
         if tenantId:


### PR DESCRIPTION
Recently the Aura API started to take as long as 15 seconds to respond to requests.  The default `httpx` timeout is 5 seconds.
This change simply overrides the default to 30 seconds.